### PR TITLE
Add Make Targets `install` and `uninstall`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,40 @@
-all:
-	gcc -Wall -Wextra -Wwrite-strings -fPIC -c -o camlink.o camlink.c
-	gcc -Wall -Wextra -Wwrite-strings -shared -o camlink.so camlink.o -ldl
+CC=gcc
+CFLAGS= -Wall -Wextra -Wwrite-strings -fPIC
+LFLAGS= -Wall -Wextra -Wwrite-strings -shared
+BUILD_DIR = build
+LIBS = camlink
+INSTALL_DIR = /usr/local/lib/camlink
+SOURCES = $(wildcard *.c)
 
+all: build
+
+LIB_TARGETS = $(addprefix $(BUILD_DIR)/, $(addsuffix .so, $(LIBS)))
+OBJECT_TARGETS = $(addprefix $(BUILD_DIR)/, $(addsuffix .o, $(basename $(SOURCES))))
+
+.PHONY: build
+build: $(LIB_TARGETS) $(OBJECT_TARGETS)
+
+$(BUILD_DIR)/%.so: $(BUILD_DIR)/%.o
+	$(CC) $(LFLAGS) -o $@ $< -ldl
+
+$(BUILD_DIR)/%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+INSTALL_TARGETS = $(addprefix $(INSTALL_DIR)/, camlink.so)
+
+.PHONY: install
+install: $(INSTALL_TARGETS)
+
+$(INSTALL_DIR)/%.so: $(BUILD_DIR)/%.so $(INSTALL_DIR)
+	cp $< $@
+
+$(INSTALL_DIR):
+	mkdir -p $(INSTALL_DIR)
+
+.PHONY: clean
 clean:
-	rm -f *.so *.o
+	rm -rf $(BUILD_DIR)/*
+
+.PHONY: uninstall
+uninstall:
+	rm -rf $(INSTALL_DIR)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ So they will not be helpful. That doesn't mean you shouldn't contact them about 
 
 There are several other possible fixes for the color issue for the Cam Link 4K:
 
-* Hack the firmware to stop returning invalid colorspaces: https://assortedhackery.com/patching-cam-link-to-play-nicer-on-linux/
+* [Hack the firmware to stop returning invalid colorspaces](https://assortedhackery.com/patching-cam-link-to-play-nicer-on-linux/)
 * [Use a dummy video source and ffmpeg to convert the color to something different](https://www.reddit.com/r/linuxhardware/comments/dzqmvq/did_anyone_tried_an_elgato_cam_link_4k_on_gnulinux/fjdsx96/)
 * Build an exception into the v4l2 driver for the Camlink to ignore the extra colorspaces
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,50 @@
 
 A small library to force removal of invalid colorspaces exported by the Elgato Cam Link 4K.
 
-## Building
+## Table of Contents
+- [Setup](#setup)
+  - [Prerequisites](#prerequisites)
+  - [Building](#building)
+  - [Installing](#installing)
+  - [Uninstalling](#uninstalling)
+- [Usage](#usage)
+- [Examples](#examples)
+  - [Video4Linux2 CTL Application](#video4linux2-ctl-application)
+  - [Zoom](#zoom)
+  - [Flatpak Zoom](#flatpak-zoom)
+  - [Firefox](#firefox)
+  - [Univesal](#universal)
+  - [Getting this to work in a desktop environment](#getting-this-to-work-in-a-desktop-environment)
+- [Troubleshooting](#troubleshooting)
+- [Alternatives](#alternatives)
+
+## Setup
+
+### Prerequisites
 
 You will need `gcc` and `make` to build.
 
-Run `make`
+[Top][toc]
 
-## Using
+### Building
+
+Run `mkdir build && make`
+
+[Top][toc]
+
+### Installing
+
+Simply run `sudo make install`. The `camlink.so` file will be copied to the path `/usr/local/lib/camlink/camlink.so`
+
+[Top][toc]
+
+### Uninstalling
+
+Run `sudo make uninstall`.
+
+[Top][toc]
+
+## Usage
 
 This library is run as a `LD_PRELOAD` to other applications. It intercepts all `ioctl` calls
 and determines if the call is intended to query the colorspaces available on a camlink.
@@ -16,35 +53,49 @@ and determines if the call is intended to query the colorspaces available on a c
 If so, it rejects all return values that are NOT `YUYV 4:2:2`. This should make colors work
 correctly on the Camlink in Linux.
 
+[Top][toc]
+
 ## Examples
 
 ### Video4Linux2 CTL application:
+
 ```
-$ LD_PRELOAD=./camlink.so v4l2-ctl -d /dev/video2 --list-formats-ext
+$ LD_PRELOAD=/usr/local/lib/camlink/camlink.so v4l2-ctl -d /dev/video2 --list-formats-ext
 ```
+
+[Top][toc]
 
 ### Zoom
 ```
-$ LD_PRELOAD=`pwd`/camlink.so zoom
+$ LD_PRELOAD=/usr/local/lib/camlink/camlink.so zoom
 ```
+
+[Top][toc]
 
 ### Flatpak Zoom
 ```
-$ flatpak override us.zoom.Zoom --filesystem=`pwd`/camlink.so
-$ flatpak run --env=LD_PRELOAD=`pwd`/camlink.so us.zoom.Zoom
+$ flatpak override us.zoom.Zoom --filesystem=/usr/local/lib/camlink/camlink.so
+$ flatpak run --env=LD_PRELOAD=/usr/local/lib/camlink/camlink.so us.zoom.Zoom
 ```
+
+[Top][toc]
 
 ### Firefox
 ```
-$ LD_PRELOAD=./camlink.so firefox
+$ LD_PRELOAD=/usr/local/lib/camlink/camlink.so firefox
 ```
+
+[Top][toc]
 
 ### Universal
 ```
-export LD_PRELOAD=`pwd`/camlink.so
+export LD_PRELOAD=/usr/local/lib/camlink/camlink.so
 ```
 
+[Top][toc]
+
 ### Getting this to work in a desktop environment
+
 Say you use Google Chrome. You click on the icon in your desktop environment, and it locates the .desktop file. (located @ `/usr/share/applications/google-chrome.desktop` on my machine)
 
 Inside that file is an `Exec=` line that specifies how to the browser should be started. On my machine, the line is:
@@ -59,20 +110,20 @@ You need to edit that line, and you need that line to STAY edited even if you up
 $ cp /usr/share/applications/google-chrome.desktop ~/.local/share/applications/
 ```
 
-Then edit the new file @ `~/.local/share/applications/google-chrome.desktop` and change the exec line to include the LD_PRELOAD call. Something like this:
+Then edit the new file @ `~/.local/share/applications/google-chrome.desktop` and change the exec line to include the LD\_PRELOAD call. Something like this:
 
 ```
-Exec=env LD_PRELOAD=/home/kwerky/camlink/camlink.so /usr/bin/google-chrome-stable %U 
+Exec=env LD_PRELOAD=/usr/local/lib/camlink/camlink.so /usr/bin/google-chrome-stable %U 
 ```
 
-### Troubleshooting
+[Top][toc]
+
+## Troubleshooting
 If running the browser on the command line DOES NOT WORK -- even after fully quitting it first:
 
-Then the issue is different; likely the `LD_PRELOAD` directory is wrong. The example I gave before `./camlink.so` should be replaced with the full path to the file. Something closer to what I mentioned before: `LD_PRELOAD=/home/yourname/camlink/camlink.so`
+Then the issue is different; likely the `LD_PRELOAD` path is incorrect. The examples assume that you have installed the camlink library. If you have not, instead use the path where your camlink.so file can be found. For example: `LD_PRELOAD=/home/yourname/path/to/camlink/sources/build/camlink.so`
 
-## Installing
-
-At some point 
+[Top][toc]
 
 ## This is a Cam Link 4K bug. What does Elgato support say?
 
@@ -88,10 +139,16 @@ I contacted Elgato about the issue and got this reply:
 
 So they will not be helpful. That doesn't mean you shouldn't contact them about the issue! Manufacterers need to know how their product is being used.
 
+[Top][toc]
+
 ## Alternatives
 
 There are several other possible fixes for the color issue for the Cam Link 4K:
 
 * Hack the firmware to stop returning invalid colorspaces: https://assortedhackery.com/patching-cam-link-to-play-nicer-on-linux/
-* Use a dummy video source and ffmpeg to convert the color to something different: https://www.reddit.com/r/linuxhardware/comments/dzqmvq/did_anyone_tried_an_elgato_cam_link_4k_on_gnulinux/fjdsx96/
+* [Use a dummy video source and ffmpeg to convert the color to something different](https://www.reddit.com/r/linuxhardware/comments/dzqmvq/did_anyone_tried_an_elgato_cam_link_4k_on_gnulinux/fjdsx96/)
 * Build an exception into the v4l2 driver for the Camlink to ignore the extra colorspaces
+
+[Top][toc]
+
+[toc]: #table-of-contents


### PR DESCRIPTION
Add make targets `install` and `uninstall` for installing and uninstalling
the camlink.so shared libary respectively.

The library is installed at the path `/usr/local/lib/camlink/camlink.so`.

Update the Makefile to include the new targets, build intermediate artifacts
in a directory called "build," and leverage make's capabilities for
dependency management and variable expansion.

Update readme to detail new build/install/usage procedures.
